### PR TITLE
Cobord/feat/ecc

### DIFF
--- a/bitgauss/benches/matrix_ops.rs
+++ b/bitgauss/benches/matrix_ops.rs
@@ -1,4 +1,4 @@
-use bitgauss::{bitmatrix::BitMatrix, bitvec::*};
+use bitgauss::{bitmatrix::BitMatrix, bitvec::{BitAndAssign, BitBlock, BitVec, BitXorAssign}};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 // use std::hint::black_box;
@@ -18,7 +18,7 @@ fn bitvec_ops(c: &mut Criterion) {
                 bv.bitxor_assign(&vec2);
             },
             BatchSize::LargeInput,
-        )
+        );
     });
 
     group.bench_function("bitvec_xor_slice", |b| {
@@ -26,7 +26,7 @@ fn bitvec_ops(c: &mut Criterion) {
             || vec3.clone(),
             |bv| bv.xor_range(10, sz + 10, sz - 20),
             BatchSize::LargeInput,
-        )
+        );
     });
 
     group.bench_function("bitvec_and", |b| {
@@ -36,7 +36,7 @@ fn bitvec_ops(c: &mut Criterion) {
                 bv.bitand_assign(&vec2);
             },
             BatchSize::LargeInput,
-        )
+        );
     });
 
     group.bench_function("bitvec_dot", |b| b.iter(|| vec1.dot(&vec2)));
@@ -47,11 +47,11 @@ fn gauss(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(1);
     let m = BitMatrix::random(&mut rng, 1000, 1000);
     group.bench_function("gauss_utri", |b| {
-        b.iter_batched_ref(|| m.clone(), |m| m.gauss(false), BatchSize::LargeInput)
+        b.iter_batched_ref(|| m.clone(), |m| m.gauss(false), BatchSize::LargeInput);
     });
 
     group.bench_function("gauss_full", |b| {
-        b.iter_batched_ref(|| m.clone(), |m| m.gauss(true), BatchSize::LargeInput)
+        b.iter_batched_ref(|| m.clone(), |m| m.gauss(true), BatchSize::LargeInput);
     });
 }
 
@@ -61,11 +61,11 @@ fn big_gauss(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(1);
     let m = BitMatrix::random(&mut rng, 10_000, 10_000);
     group.bench_function("big_gauss_utri", |b| {
-        b.iter_batched_ref(|| m.clone(), |m| m.gauss(false), BatchSize::LargeInput)
+        b.iter_batched_ref(|| m.clone(), |m| m.gauss(false), BatchSize::LargeInput);
     });
 
     group.bench_function("big_gauss_full", |b| {
-        b.iter_batched_ref(|| m.clone(), |m| m.gauss(true), BatchSize::LargeInput)
+        b.iter_batched_ref(|| m.clone(), |m| m.gauss(true), BatchSize::LargeInput);
     });
 }
 
@@ -87,19 +87,19 @@ fn transpose(c: &mut Criterion) {
                 }
             },
             BatchSize::LargeInput,
-        )
+        );
     });
 
     group.bench_function("inplace", |b| {
         b.iter_batched_ref(
             || m.clone(),
-            |m| m.transpose_inplace(),
+            BitMatrix::transpose_inplace,
             BatchSize::LargeInput,
-        )
+        );
     });
 
     group.bench_function("copied", |b| {
-        b.iter_batched_ref(|| m.clone(), |m| m.transposed(), BatchSize::LargeInput)
+        b.iter_batched_ref(|| m.clone(), |m| m.transposed(), BatchSize::LargeInput);
     });
 }
 

--- a/bitgauss/benches/matrix_ops.rs
+++ b/bitgauss/benches/matrix_ops.rs
@@ -1,4 +1,7 @@
-use bitgauss::{bitmatrix::BitMatrix, bitvec::{BitAndAssign, BitBlock, BitVec, BitXorAssign}};
+use bitgauss::{
+    bitmatrix::BitMatrix,
+    bitvec::{BitAndAssign, BitBlock, BitVec, BitXorAssign},
+};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 // use std::hint::black_box;

--- a/bitgauss/src/binary_codes.rs
+++ b/bitgauss/src/binary_codes.rs
@@ -1,0 +1,202 @@
+use std::{fmt, ops::Div};
+
+use crate::{BitBlock, BitMatrix, BitVec};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ECCError(pub String);
+
+// Standard implementations of error traits for `BitMatrixError`
+impl std::fmt::Display for ECCError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ECCError: {}", self.0)
+    }
+}
+impl std::error::Error for ECCError {}
+
+pub struct BinaryLinearCode {
+    pub(crate) n_codeword_length: usize,
+    pub(crate) k_codespace_dimension: usize,
+    pub(crate) d_code_distance: usize,
+    pub(crate) g_generator_matrix: BitMatrix,
+    known_is_standard: Option<bool>,
+}
+
+impl BinaryLinearCode {
+    /// Each row of `to_encode` represents a bitvector being encoded
+    /// That is to say `to_encode` is R by `k_codespace_dimension`
+    /// and after encoding we get a result of R by `n_codeword_length`
+    ///
+    /// # Errors
+    ///
+    /// If the number of columns of `to_encode` are incorrect for the dimension
+    /// of the codespace
+    pub fn encode(&self, to_encode: &BitMatrix) -> Result<BitMatrix, ECCError> {
+        if self.k_codespace_dimension != to_encode.cols() {
+            return Err(ECCError(
+                "the quantity to be encoded did not have the right number of columns".to_owned(),
+            ));
+        }
+        Ok(to_encode * &self.g_generator_matrix)
+    }
+
+    /// the standard `[n,k,d]_q` notation
+    pub fn n_k_d_q(&self) -> [usize; 4] {
+        [
+            self.n_codeword_length,
+            self.k_codespace_dimension,
+            self.d_code_distance,
+            2,
+        ]
+    }
+
+    /// Give the rate of information transfer.
+    /// For a codespace of dimension `k` and codewords of length `n`
+    /// the information transfer is slowed by a factor of `k/n`.
+    /// This is compensated by the benefit of being able to detect and correct errors.
+    pub fn rate<T: From<usize> + Div<T, Output = T>>(&self) -> T {
+        let [n, k, _, _] = self.n_k_d_q();
+        let n_t: T = n.into();
+        let k_t: T = k.into();
+        k_t / n_t
+    }
+
+    /// Is the G matrix in standard form with [I | P]
+    ///
+    /// # Panics
+    ///
+    /// The `k_codespace_dimension` by `n_codeword_length` matrix `g_generator_matrix`
+    /// is assumed to have no more rows than columns
+    /// the rate will be `<= 1`
+    pub fn is_standard(&self) -> bool {
+        if let Some(known_is_standard) = self.known_is_standard {
+            return known_is_standard;
+        }
+        let cols_selected = (0..self.k_codespace_dimension).collect::<Vec<_>>();
+        let left_block = self
+            .g_generator_matrix
+            .select_cols(&cols_selected)
+            .expect("The matrix has fewer rows than columns by assumption");
+        left_block == BitMatrix::identity(self.k_codespace_dimension)
+    }
+}
+
+#[repr(transparent)]
+pub struct HadamardCode(BinaryLinearCode);
+
+impl HadamardCode {
+    /// Each row of `to_encode` represents a bitvector being encoded
+    /// That is to say `to_encode` is R by `k_codespace_dimension`
+    /// and after encoding we get a result of R by `n_codeword_length`
+    ///
+    /// # Errors
+    ///
+    /// If the number of columns of `to_encode` are incorrect for the dimension
+    /// of the codespace
+    pub fn encode(&self, to_encode: &BitMatrix) -> Result<BitMatrix, ECCError> {
+        self.0.encode(to_encode)
+    }
+
+    /// the standard `[n,k,d]_q` notation
+    pub fn n_k_d_q(&self) -> [usize; 4] {
+        self.0.n_k_d_q()
+    }
+
+    /// Give the rate of information transfer.
+    /// For a codespace of dimension `k` and codewords of length `n`
+    /// the information transfer is slowed by a factor of `k/n`.
+    /// This is compensated by the benefit of being able to detect and correct errors.
+    pub fn rate<T: From<usize> + Div<T, Output = T>>(&self) -> T {
+        self.0.rate()
+    }
+}
+
+impl HadamardCode {
+    pub fn new(k_codespace_dimension: usize, augmented: bool) -> Self {
+        let n_codeword_length: usize = 1 << k_codespace_dimension;
+        let starting: BitBlock = if augmented {
+            (n_codeword_length >> 1) as BitBlock
+        } else {
+            0
+        };
+        let iter = (starting..n_codeword_length as BitBlock).map(|z| {
+            let b: BitVec = vec![z.rotate_right(k_codespace_dimension as u32)].into();
+            BitMatrix::row_vector(k_codespace_dimension, b)
+        });
+        let mut g_generator_matrix = BitMatrix::vstack_from_owned_iter(iter);
+        g_generator_matrix.transpose_inplace();
+        let n_codeword_length = if augmented {
+            n_codeword_length >> 1
+        } else {
+            n_codeword_length
+        };
+        Self(BinaryLinearCode {
+            n_codeword_length,
+            k_codespace_dimension,
+            d_code_distance: n_codeword_length >> 1,
+            g_generator_matrix,
+            known_is_standard: Some(false),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn hadamard_3_8() {
+        let cur_had = HadamardCode::new(3, false);
+        assert_eq!(cur_had.0.n_codeword_length, 8);
+        assert_eq!(cur_had.0.k_codespace_dimension, 3);
+        assert_eq!(cur_had.0.d_code_distance, 4);
+        assert_eq!(cur_had.0.g_generator_matrix.rows(), 3);
+        assert_eq!(cur_had.0.g_generator_matrix.cols(), 8);
+        let a = [
+            [0, 0, 0],
+            [0, 0, 1],
+            [0, 1, 0],
+            [0, 1, 1],
+            [1, 0, 0],
+            [1, 0, 1],
+            [1, 1, 0],
+            [1, 1, 1],
+        ];
+        for k_idx in 0..3 {
+            for n_idx in 0..8 {
+                assert_eq!(
+                    a[n_idx][k_idx] == 1,
+                    cur_had.0.g_generator_matrix.bit(k_idx, n_idx),
+                    "G[{k_idx}{n_idx}]"
+                );
+            }
+        }
+        assert_eq!(
+            cur_had.0.g_generator_matrix,
+            BitMatrix::build(3, 8, |i, j| a[j][i] == 1)
+        );
+    }
+
+    #[test]
+    fn augmented_hadamard_3_4() {
+        let cur_had = HadamardCode::new(3, true);
+        assert_eq!(cur_had.0.n_codeword_length, 4);
+        assert_eq!(cur_had.0.k_codespace_dimension, 3);
+        assert_eq!(cur_had.0.d_code_distance, 2);
+        assert_eq!(cur_had.0.g_generator_matrix.rows(), 3);
+        assert_eq!(cur_had.0.g_generator_matrix.cols(), 4);
+        let a = [[1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]];
+        for k_idx in 0..3 {
+            for n_idx in 0..4 {
+                assert_eq!(
+                    a[n_idx][k_idx] == 1,
+                    cur_had.0.g_generator_matrix.bit(k_idx, n_idx),
+                    "G[{k_idx}{n_idx}]"
+                );
+            }
+        }
+        assert_eq!(
+            cur_had.0.g_generator_matrix,
+            BitMatrix::build(3, 4, |i, j| a[j][i] == 1)
+        );
+    }
+}

--- a/bitgauss/src/binary_codes.rs
+++ b/bitgauss/src/binary_codes.rs
@@ -13,12 +13,43 @@ impl std::fmt::Display for ECCError {
 }
 impl std::error::Error for ECCError {}
 
+enum ECCPresentations {
+    JustG(BitMatrix),
+    StandardP(BitMatrix),
+    #[allow(dead_code)]
+    BothGH(BitMatrix,BitMatrix),
+}
+
+impl ECCPresentations {
+    #[allow(dead_code)]
+    fn valid(&self) -> bool {
+        match self {
+            ECCPresentations::JustG(bit_matrix) => {
+                bit_matrix.rows() < bit_matrix.cols()
+            },
+            ECCPresentations::StandardP(_) => {
+                true
+            },
+            ECCPresentations::BothGH(g_matrix, h_matrix) => {
+                let (k_g,n_g) = (g_matrix.rows(), g_matrix.cols());
+                let (n_minus_k_h, n_h)= (h_matrix.rows(), h_matrix.cols());
+                if n_g == n_h && n_minus_k_h + k_g == n_g {
+                    let g_transpose = g_matrix.transposed();
+                    let h_times_g_t = h_matrix * &g_transpose;
+                    h_times_g_t == BitMatrix::zeros(n_minus_k_h, k_g)
+                } else {
+                    false
+                }
+            },
+        }
+    }
+}
+
 pub struct BinaryLinearCode {
-    pub(crate) n_codeword_length: usize,
-    pub(crate) k_codespace_dimension: usize,
-    pub(crate) d_code_distance: usize,
-    pub(crate) g_generator_matrix: BitMatrix,
-    known_is_standard: Option<bool>,
+    n_codeword_length: usize,
+    k_codespace_dimension: usize,
+    d_code_distance: usize,
+    chosen_presentation: ECCPresentations,
 }
 
 impl BinaryLinearCode {
@@ -36,7 +67,62 @@ impl BinaryLinearCode {
                 "the quantity to be encoded did not have the right number of columns".to_owned(),
             ));
         }
-        Ok(to_encode * &self.g_generator_matrix)
+        match &self.chosen_presentation {
+            ECCPresentations::JustG(g_generator_matrix)
+            | ECCPresentations::BothGH(g_generator_matrix, _)
+            => {
+                        Ok(to_encode * g_generator_matrix)
+                    },
+            ECCPresentations::StandardP(p_part_of_g) => {
+                        let left_part = to_encode.clone();
+                        let right_part = to_encode * p_part_of_g;
+                        Ok(BitMatrix::hstack(&left_part, &right_part))
+                    }
+        }
+    }
+
+    /// Each column of `to_decode` represents a bitvector being decoded
+    /// That is to say `to_decode` is `n_codeword_length` by C
+    /// and after decoding we would get a result of `k_codespace_dimension` by C
+    ///
+    /// # Errors
+    ///
+    /// If the number of rows of `to_decode` are incorrect for the dimension
+    /// of the codewords
+    pub fn is_codeword(&self, to_decode: &BitMatrix) -> Result<BitVec, ECCError> {
+        if self.n_codeword_length != to_decode.rows() {
+            return Err(ECCError(
+                "the quantity to be decoded did not have the right number of rows".to_owned(),
+            ));
+        }
+        match &self.chosen_presentation {
+            ECCPresentations::JustG(_) => {
+                Err(ECCError(
+                    "We do not have the check matrix, we need to compute it".to_owned(),
+                ))
+            }
+            ECCPresentations::StandardP(bit_matrix) => {
+                let p_transpose = bit_matrix.transposed();
+                let identity_part = BitMatrix::identity(p_transpose.rows());
+                let full_h = BitMatrix::hstack(&p_transpose, &identity_part);
+                let count_columns = to_decode.cols();
+                let mut to_check_zero_columns = &full_h * to_decode;
+                to_check_zero_columns.transpose_inplace();
+                let to_check_zero_rows = to_check_zero_columns;
+                Ok((0..count_columns).map(|cur_row| {
+                    to_check_zero_rows.row(cur_row).has_any_ones()
+                }).collect())
+            },
+            ECCPresentations::BothGH(_, full_h) => {
+                let count_columns = to_decode.cols();
+                let mut to_check_zero_columns = full_h * to_decode;
+                to_check_zero_columns.transpose_inplace();
+                let to_check_zero_rows = to_check_zero_columns;
+                Ok((0..count_columns).map(|cur_row| {
+                    to_check_zero_rows.row(cur_row).has_any_ones()
+                }).collect())
+            },
+        }
     }
 
     /// the standard `[n,k,d]_q` notation
@@ -60,23 +146,75 @@ impl BinaryLinearCode {
         k_t / n_t
     }
 
-    /// Is the G matrix in standard form with [I | P]
+    /// Is the G matrix in standard form with [I | P]?
+    /// This can be either explicitly as the `StandardP` variant or possibly checking the left block
+    /// to see if it is the identity matrix.
     ///
     /// # Panics
     ///
     /// The `k_codespace_dimension` by `n_codeword_length` matrix `g_generator_matrix`
     /// is assumed to have no more rows than columns
     /// the rate will be `<= 1`
-    pub fn is_standard(&self) -> bool {
-        if let Some(known_is_standard) = self.known_is_standard {
-            return known_is_standard;
+    pub fn is_standard(&self, only_obviously: bool) -> bool {
+        if only_obviously {
+            return matches!(self.chosen_presentation, ECCPresentations::StandardP(_));
         }
-        let cols_selected = (0..self.k_codespace_dimension).collect::<Vec<_>>();
-        let left_block = self
-            .g_generator_matrix
-            .select_cols(&cols_selected)
-            .expect("The matrix has fewer rows than columns by assumption");
-        left_block == BitMatrix::identity(self.k_codespace_dimension)
+        match &self.chosen_presentation {
+            ECCPresentations::JustG(g_generator_matrix)
+            | ECCPresentations::BothGH(g_generator_matrix, _) => {
+                let cols_selected = (0..self.k_codespace_dimension).collect::<Vec<_>>();
+                let left_block = g_generator_matrix
+                    .select_cols(&cols_selected)
+                    .expect("The matrix has fewer rows than columns by assumption");
+                left_block == BitMatrix::identity(self.k_codespace_dimension)
+            },
+            ECCPresentations::StandardP(_) => true,
+        }
+    }
+
+    
+    /// Either give a reference to the `G` matrix in the `Ok` variant
+    /// or reconstruct it from the `P` matrix in the `Err` variant
+    #[allow(clippy::missing_errors_doc)]
+    pub fn g_generator_matrix(&self) -> Result<&BitMatrix,BitMatrix> {
+        match &self.chosen_presentation {
+            ECCPresentations::JustG(bit_matrix)
+            | ECCPresentations::BothGH(bit_matrix,_) => Ok(bit_matrix),
+            ECCPresentations::StandardP(bit_matrix) => {
+                Err(BitMatrix::hstack(&BitMatrix::identity(self.k_codespace_dimension), bit_matrix))
+            },
+        }
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    pub fn standardize(self) -> Self {
+        if self.is_standard(true) {
+            return self;
+        }
+        match self.chosen_presentation {
+            ECCPresentations::JustG(mut bit_matrix)
+            | ECCPresentations::BothGH(mut bit_matrix, _)
+            => {
+                let pivot_cols = bit_matrix.gauss(true);
+                let num_cols = bit_matrix.cols();
+                let chosen_presentation = if pivot_cols.len() == self.k_codespace_dimension {
+                    let cols_for_p_selected = (0..num_cols).filter(|z| !pivot_cols.contains(z)).collect::<Vec<_>>();
+                    let p_matrix = bit_matrix.select_cols(&cols_for_p_selected).expect("Manifestly all within range of logical columns");
+                    ECCPresentations::StandardP(p_matrix)
+                } else {
+                    ECCPresentations::JustG(bit_matrix)
+                };
+                Self {
+                    n_codeword_length: self.n_codeword_length,
+                    k_codespace_dimension: self.k_codespace_dimension,
+                    d_code_distance: self.d_code_distance,
+                    chosen_presentation,
+                }
+            }
+            ECCPresentations::StandardP(_) => {
+                unreachable!("Already checked that it was not standard already");
+            }
+        }
     }
 }
 
@@ -133,8 +271,7 @@ impl HadamardCode {
             n_codeword_length,
             k_codespace_dimension,
             d_code_distance: n_codeword_length >> 1,
-            g_generator_matrix,
-            known_is_standard: Some(false),
+            chosen_presentation: ECCPresentations::JustG(g_generator_matrix),
         })
     }
 }
@@ -149,8 +286,8 @@ mod test {
         assert_eq!(cur_had.0.n_codeword_length, 8);
         assert_eq!(cur_had.0.k_codespace_dimension, 3);
         assert_eq!(cur_had.0.d_code_distance, 4);
-        assert_eq!(cur_had.0.g_generator_matrix.rows(), 3);
-        assert_eq!(cur_had.0.g_generator_matrix.cols(), 8);
+        assert_eq!(cur_had.0.g_generator_matrix().expect("Is given as G").rows(), 3);
+        assert_eq!(cur_had.0.g_generator_matrix().expect("Is given as G").cols(), 8);
         let a = [
             [0, 0, 0],
             [0, 0, 1],
@@ -165,13 +302,13 @@ mod test {
             for n_idx in 0..8 {
                 assert_eq!(
                     a[n_idx][k_idx] == 1,
-                    cur_had.0.g_generator_matrix.bit(k_idx, n_idx),
+                    cur_had.0.g_generator_matrix().expect("Is given as G").bit(k_idx, n_idx),
                     "G[{k_idx}{n_idx}]"
                 );
             }
         }
         assert_eq!(
-            cur_had.0.g_generator_matrix,
+            *cur_had.0.g_generator_matrix().expect("Is given as G"),
             BitMatrix::build(3, 8, |i, j| a[j][i] == 1)
         );
     }
@@ -182,20 +319,20 @@ mod test {
         assert_eq!(cur_had.0.n_codeword_length, 4);
         assert_eq!(cur_had.0.k_codespace_dimension, 3);
         assert_eq!(cur_had.0.d_code_distance, 2);
-        assert_eq!(cur_had.0.g_generator_matrix.rows(), 3);
-        assert_eq!(cur_had.0.g_generator_matrix.cols(), 4);
+        assert_eq!(cur_had.0.g_generator_matrix().expect("Is given as G").rows(), 3);
+        assert_eq!(cur_had.0.g_generator_matrix().expect("Is given as G").cols(), 4);
         let a = [[1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]];
         for k_idx in 0..3 {
             for n_idx in 0..4 {
                 assert_eq!(
                     a[n_idx][k_idx] == 1,
-                    cur_had.0.g_generator_matrix.bit(k_idx, n_idx),
+                    cur_had.0.g_generator_matrix().expect("Is given as G").bit(k_idx, n_idx),
                     "G[{k_idx}{n_idx}]"
                 );
             }
         }
         assert_eq!(
-            cur_had.0.g_generator_matrix,
+            *cur_had.0.g_generator_matrix().expect("Is given as G"),
             BitMatrix::build(3, 4, |i, j| a[j][i] == 1)
         );
     }

--- a/bitgauss/src/bitmatrix.rs
+++ b/bitgauss/src/bitmatrix.rs
@@ -1,4 +1,4 @@
-use crate::bitvec::{BLOCKSIZE, BitBlock, BitSlice, BitVec, MSB_ON, min_blocks};
+use crate::bitvec::{min_blocks, BitBlock, BitSlice, BitVec, BLOCKSIZE, MSB_ON};
 use rand::Rng;
 use std::{
     fmt,
@@ -387,9 +387,9 @@ impl BitMatrix {
     }
 
     /// Computes the inverse of the matrix if it is invertible, otherwise returns an error
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// If the matrix is not invertible. This includes the possibilities of not being square and having rank too small.
     pub fn try_inverse(&self) -> Result<Self, BitMatrixError> {
         if self.rows() != self.cols() {
@@ -406,9 +406,9 @@ impl BitMatrix {
     }
 
     /// Computes the inverse of an invertible matrix
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// If the matrix is not invertible. This includes the possibilities of not being square and having rank too small.
     pub fn inverse(&self) -> Self {
         self.try_inverse().unwrap()
@@ -417,7 +417,7 @@ impl BitMatrix {
     /// Tries to multiply two matrices and returns the result
     ///
     /// # Errors
-    /// 
+    ///
     /// Returns an error if the matrices have incompatible dimensions
     pub fn try_mul(&self, other: &Self) -> Result<Self, BitMatrixError> {
         if self.cols() != other.rows() {
@@ -447,9 +447,9 @@ impl BitMatrix {
     /// Try to vertically stack this matrix with another one and returns the result
     ///
     /// The resulting matrix will have the minimal column padding.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns an error if the matrices have different numbers of columns.
     pub fn try_vstack(&self, other: &Self) -> Result<Self, BitMatrixError> {
         if self.cols() != other.cols() {
@@ -484,18 +484,18 @@ impl BitMatrix {
     }
 
     /// Vertically stacks this matrix with another one and returns the result
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Returns an error if the matrices have different numbers of columns.
     pub fn vstack(&self, other: &Self) -> Self {
         self.try_vstack(other).unwrap()
     }
 
     /// Horizontally stacks this matrix with another one and returns the result
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns an error if the matrices have different numbers of rows.
     pub fn try_hstack(&self, other: &Self) -> Result<Self, BitMatrixError> {
         if self.rows() != other.rows() {
@@ -538,9 +538,9 @@ impl BitMatrix {
     }
 
     /// Horizontally stacks this matrix with another one and returns the result
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Returns an error if the matrices have different numbers of rows.
     pub fn hstack(&self, other: &Self) -> Self {
         self.try_hstack(other).unwrap()

--- a/bitgauss/src/bitmatrix.rs
+++ b/bitgauss/src/bitmatrix.rs
@@ -379,8 +379,8 @@ impl BitMatrix {
     /// If `full` is true, then perform full Gauss-Jordan to produce reduced echelon form, otherwise
     /// just returns echelon form.
     #[inline]
-    pub fn gauss(&mut self, full: bool) {
-        self.gauss_helper(full, 1, &mut ());
+    pub fn gauss(&mut self, full: bool) -> Vec<usize> {
+        self.gauss_helper(full, 1, &mut ())
     }
 
     /// Performs gaussian elimination with a `blocksize` and a `proxy`

--- a/bitgauss/src/bitvec.rs
+++ b/bitgauss/src/bitvec.rs
@@ -1,7 +1,10 @@
 use rand::Rng;
 use ref_cast::RefCast;
-use std::fmt;
 pub use std::ops::{BitAndAssign, BitXorAssign, Deref, DerefMut, Index, IndexMut, Range};
+use std::{
+    fmt,
+    ops::{BitOrAssign, Not},
+};
 
 /// A block of bits. This is an alias for [`u64`]
 pub type BitBlock = u64;
@@ -482,6 +485,26 @@ impl BitXorAssign<&Self> for BitSlice {
         for (bits0, bits1) in self.0.iter_mut().zip(rhs.0.iter()) {
             *bits0 ^= bits1;
         }
+    }
+}
+
+impl BitOrAssign<&Self> for BitSlice {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: &BitSlice) {
+        for (bits0, bits1) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *bits0 |= bits1;
+        }
+    }
+}
+
+impl Not for BitVec {
+    type Output = Self;
+
+    fn not(mut self) -> Self::Output {
+        self.0.iter_mut().for_each(|bits| {
+            *bits = !*bits;
+        });
+        self
     }
 }
 

--- a/bitgauss/src/bitvec.rs
+++ b/bitgauss/src/bitvec.rs
@@ -121,6 +121,12 @@ impl BitSlice {
         self.block_iter().fold(0, |c, bits| c + bits.count_ones())
     }
 
+    /// Whether any number of bits set to 1 in the entire range.
+    #[inline]
+    pub fn has_any_ones(&self) -> bool {
+        self.block_iter().any(|bits| bits != 0)
+    }
+
     /// Counts the number of bits set to 0 in the entire range.
     #[inline]
     pub fn count_zeros(&self) -> u32 {

--- a/bitgauss/src/bitvec.rs
+++ b/bitgauss/src/bitvec.rs
@@ -401,9 +401,9 @@ impl BitVec {
     /// Extends a [`BitVec`] with the contents of a [`BitSlice`], left-shifting the bits in each block
     ///
     /// Note this method assumes that the last `shift` bits in `self` are zero
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// the shift must be less than the block size and `self` cannot be empty
     pub fn extend_from_slice_left_shifted(&mut self, other: &BitSlice, shift: usize) {
         if shift >= BLOCKSIZE {

--- a/bitgauss/src/lib.rs
+++ b/bitgauss/src/lib.rs
@@ -22,8 +22,10 @@
     clippy::return_self_not_must_use,
     clippy::bool_to_int_with_if
 )]
+pub mod binary_codes;
 pub mod bitmatrix;
 pub mod bitvec;
 
+pub use binary_codes::{BinaryLinearCode, HadamardCode};
 pub use bitmatrix::{BitMatrix, RowOps};
 pub use bitvec::{BitBlock, BitSlice, BitVec};

--- a/bitgauss/src/lib.rs
+++ b/bitgauss/src/lib.rs
@@ -12,7 +12,15 @@
 //! - [`BitMatrix`]: a two-dimensional matrix based on `BitVec`, which implements
 //!   basic linear algebraic operations
 
-#[allow(clippy::needless_range_loop, clippy::suspicious_arithmetic_impl)]
+#![allow(clippy::needless_range_loop,
+    clippy::suspicious_arithmetic_impl,
+    clippy::uninlined_format_args,
+    clippy::bool_assert_comparison,
+    clippy::cast_possible_truncation,
+    clippy::must_use_candidate,
+    clippy::return_self_not_must_use,
+    clippy::bool_to_int_with_if,
+)]
 pub mod bitmatrix;
 pub mod bitvec;
 

--- a/bitgauss/src/lib.rs
+++ b/bitgauss/src/lib.rs
@@ -12,14 +12,15 @@
 //! - [`BitMatrix`]: a two-dimensional matrix based on `BitVec`, which implements
 //!   basic linear algebraic operations
 
-#![allow(clippy::needless_range_loop,
+#![allow(
+    clippy::needless_range_loop,
     clippy::suspicious_arithmetic_impl,
     clippy::uninlined_format_args,
     clippy::bool_assert_comparison,
     clippy::cast_possible_truncation,
     clippy::must_use_candidate,
     clippy::return_self_not_must_use,
-    clippy::bool_to_int_with_if,
+    clippy::bool_to_int_with_if
 )]
 pub mod bitmatrix;
 pub mod bitvec;

--- a/bitgauss/src/lib.rs
+++ b/bitgauss/src/lib.rs
@@ -25,7 +25,9 @@
 pub mod binary_codes;
 pub mod bitmatrix;
 pub mod bitvec;
+pub mod quantum_ecc;
 
 pub use binary_codes::{BinaryLinearCode, HadamardCode};
 pub use bitmatrix::{BitMatrix, RowOps};
 pub use bitvec::{BitBlock, BitSlice, BitVec};
+pub use quantum_ecc::{F2nSymplectic, PauliString, SGenerators};

--- a/bitgauss/src/quantum_ecc/f2n_symplectic.rs
+++ b/bitgauss/src/quantum_ecc/f2n_symplectic.rs
@@ -1,0 +1,105 @@
+use std::{
+    fmt::Display,
+    ops::{Add, AddAssign},
+};
+
+use crate::{bitvec::min_blocks, BitVec};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct F2nSymplectic {
+    pub(crate) first_part: BitVec,
+    pub(crate) second_part: BitVec,
+    pub(crate) my_n: usize,
+}
+
+impl Display for F2nSymplectic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "Xs: {:?}",
+            self.first_part
+                .into_iter()
+                .take(self.my_n)
+                .map(|b| if b { '1' } else { '0' })
+                .collect::<String>()
+        ))?;
+        f.write_fmt(format_args!(
+            "Zs: {:?}",
+            self.second_part
+                .into_iter()
+                .take(self.my_n)
+                .map(|b| if b { '1' } else { '0' })
+                .collect::<String>()
+        ))?;
+        Ok(())
+    }
+}
+
+impl F2nSymplectic {
+    /// The standard form on `F_2^{2n}`
+    ///
+    /// # Panics
+    ///
+    /// The two must be in the same vector space with the same `n`.
+    pub fn omega(&self, other: &Self) -> bool {
+        assert_eq!(self.my_n, other.my_n);
+        let a = self.first_part.dot(&other.second_part);
+        let b = self.second_part.dot(&other.first_part);
+        a ^ b
+    }
+
+    pub(crate) fn weight(&self) -> u32 {
+        let mut either_ones = self.first_part.clone();
+        *either_ones |= &self.second_part;
+        either_ones.count_ones()
+    }
+
+    /// Conjugate by `H` on the specified qubits.
+    /// If on all of them, we do them all at once with a single `mem::swap`.
+    /// If on none of them, we do nothing.
+    /// Otherwise we do the switching of roles of `X` and `Z` only for that qubit.
+    pub fn hadamard_transform(&mut self, mut where_hs: BitVec) {
+        if where_hs.num_bits() < self.my_n {
+            where_hs.extend_from_slice(&BitVec::zeros(min_blocks(self.my_n)));
+        }
+        if where_hs.count_zeros() == 0 {
+            core::mem::swap(&mut self.first_part, &mut self.second_part);
+            return;
+        }
+        if where_hs.count_ones() == 0 {
+            return;
+        }
+        for (idx, cur_h_bit) in where_hs.into_iter().take(self.my_n).enumerate() {
+            if cur_h_bit {
+                let from_first = self.first_part.bit(idx);
+                let from_second = self.second_part.bit(idx);
+                self.first_part.set_bit(idx, from_second);
+                self.second_part.set_bit(idx, from_first);
+            }
+        }
+    }
+}
+
+impl Add for &F2nSymplectic {
+    type Output = F2nSymplectic;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        assert_eq!(self.my_n, rhs.my_n);
+        let mut first_part = self.first_part.clone();
+        let mut second_part = self.second_part.clone();
+        *first_part ^= &rhs.first_part;
+        *second_part ^= &rhs.second_part;
+        F2nSymplectic {
+            first_part,
+            second_part,
+            my_n: self.my_n,
+        }
+    }
+}
+
+impl AddAssign<&Self> for F2nSymplectic {
+    fn add_assign(&mut self, rhs: &Self) {
+        assert_eq!(self.my_n, rhs.my_n);
+        *self.first_part ^= &rhs.first_part;
+        *self.second_part ^= &rhs.second_part;
+    }
+}

--- a/bitgauss/src/quantum_ecc/mod.rs
+++ b/bitgauss/src/quantum_ecc/mod.rs
@@ -1,0 +1,6 @@
+mod f2n_symplectic;
+mod pauli;
+mod stabilizer;
+
+pub use f2n_symplectic::F2nSymplectic;
+pub use stabilizer::{PauliString, SGenerators};

--- a/bitgauss/src/quantum_ecc/pauli.rs
+++ b/bitgauss/src/quantum_ecc/pauli.rs
@@ -1,0 +1,88 @@
+#![allow(clippy::suspicious_op_assign_impl)]
+use std::ops::{AddAssign, MulAssign};
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum PauliLetter {
+    I,
+    X,
+    Y,
+    Z,
+}
+
+#[allow(dead_code)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum IPower {
+    One,
+    PlusI,
+    NegOne,
+    NegI,
+}
+
+impl IPower {
+    fn to_u8(self) -> u8 {
+        match self {
+            IPower::One => 0,
+            IPower::PlusI => 1,
+            IPower::NegOne => 2,
+            IPower::NegI => 3,
+        }
+    }
+}
+
+impl MulAssign<IPower> for IPower {
+    fn mul_assign(&mut self, rhs: IPower) {
+        *self += rhs.to_u8();
+    }
+}
+
+impl AddAssign<u8> for IPower {
+    #[inline]
+    fn add_assign(&mut self, rhs: u8) {
+        match rhs % 4 {
+            0 => {}
+            1 => match self {
+                IPower::One => {
+                    *self = IPower::PlusI;
+                }
+                IPower::PlusI => {
+                    *self = IPower::NegOne;
+                }
+                IPower::NegOne => {
+                    *self = IPower::NegI;
+                }
+                IPower::NegI => {
+                    *self = IPower::One;
+                }
+            },
+            2 => match self {
+                IPower::One => {
+                    *self = IPower::NegOne;
+                }
+                IPower::PlusI => {
+                    *self = IPower::NegI;
+                }
+                IPower::NegOne => {
+                    *self = IPower::One;
+                }
+                IPower::NegI => {
+                    *self = IPower::PlusI;
+                }
+            },
+            3 => match self {
+                IPower::One => {
+                    *self = IPower::NegI;
+                }
+                IPower::PlusI => {
+                    *self = IPower::One;
+                }
+                IPower::NegOne => {
+                    *self = IPower::PlusI;
+                }
+                IPower::NegI => {
+                    *self = IPower::NegOne;
+                }
+            },
+            _ => unreachable!(),
+        }
+    }
+}

--- a/bitgauss/src/quantum_ecc/stabilizer.rs
+++ b/bitgauss/src/quantum_ecc/stabilizer.rs
@@ -1,0 +1,512 @@
+use std::{fmt::Display, ops::MulAssign};
+
+use crate::{
+    bitvec::min_blocks,
+    quantum_ecc::{
+        f2n_symplectic::F2nSymplectic,
+        pauli::{IPower, PauliLetter},
+    },
+    BitMatrix, BitVec, RowOps,
+};
+
+impl From<&F2nSymplectic> for Vec<PauliLetter> {
+    fn from(f2n_symplectic: &F2nSymplectic) -> Self {
+        let mut to_return = Vec::with_capacity(f2n_symplectic.my_n);
+        let first_iter = f2n_symplectic
+            .first_part
+            .into_iter()
+            .take(f2n_symplectic.my_n);
+        let second_iter = f2n_symplectic
+            .second_part
+            .into_iter()
+            .take(f2n_symplectic.my_n);
+        for (x_part, z_part) in first_iter.zip(second_iter) {
+            match (x_part, z_part) {
+                (true, true) => {
+                    to_return.push(PauliLetter::Y);
+                }
+                (true, false) => {
+                    to_return.push(PauliLetter::X);
+                }
+                (false, true) => {
+                    to_return.push(PauliLetter::Z);
+                }
+                (false, false) => {
+                    to_return.push(PauliLetter::I);
+                }
+            }
+        }
+        to_return
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct PauliString {
+    #[allow(dead_code)]
+    overall_factor: IPower,
+    pauli_letters: F2nSymplectic,
+}
+
+impl Display for PauliString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?} * ", self.overall_factor))?;
+        f.write_fmt(format_args!(
+            "{:?}",
+            Vec::<PauliLetter>::from(&self.pauli_letters)
+        ))?;
+        Ok(())
+    }
+}
+
+impl PauliString {
+    /// Parse a shorthand string like XZZIXX
+    /// with no prefactor.
+    /// If you want the prefactor, parse and then multiply by `IPower` after that
+    pub fn parse(s: &str) -> Option<Self> {
+        let mut pauli_letters = Vec::with_capacity(s.len());
+        for letter in s.chars() {
+            if letter.is_whitespace() || letter.is_ascii_punctuation() {
+            } else if letter == '0' || letter == 'I' || letter == 'i' {
+                pauli_letters.push(PauliLetter::I);
+            } else if letter == 'X' || letter == 'x' {
+                pauli_letters.push(PauliLetter::X);
+            } else if letter == 'Y' || letter == 'y' {
+                pauli_letters.push(PauliLetter::Y);
+            } else if letter == 'Z' || letter == 'z' {
+                pauli_letters.push(PauliLetter::Z);
+            } else {
+                return None;
+            }
+        }
+        Some(Self {
+            overall_factor: IPower::One,
+            pauli_letters: F2nSymplectic::from(pauli_letters.into_iter()),
+        })
+    }
+
+    pub fn weight_one(
+        where_nontrivial: usize,
+        how_many_total: usize,
+        which_letter: PauliLetter,
+        overall_factor: IPower,
+    ) -> Self {
+        let mut x_vector = BitVec::zeros(min_blocks(how_many_total));
+        let mut z_vector = BitVec::zeros(min_blocks(how_many_total));
+        match which_letter {
+            PauliLetter::I => {}
+            PauliLetter::X => {
+                x_vector.set_bit(where_nontrivial, true);
+            }
+            PauliLetter::Y => {
+                x_vector.set_bit(where_nontrivial, true);
+                z_vector.set_bit(where_nontrivial, true);
+            }
+            PauliLetter::Z => {
+                z_vector.set_bit(where_nontrivial, true);
+            }
+        }
+        Self {
+            overall_factor,
+            pauli_letters: F2nSymplectic {
+                first_part: x_vector,
+                second_part: z_vector,
+                my_n: how_many_total,
+            },
+        }
+    }
+
+    /// Do these two commute in `P_n`
+    pub fn commutes_with(&self, other: &Self) -> bool {
+        !self.pauli_letters.omega(&other.pauli_letters)
+    }
+
+    pub fn weight(&self) -> u32 {
+        self.pauli_letters.weight()
+    }
+}
+
+impl<T> From<T> for F2nSymplectic
+where
+    T: ExactSizeIterator<Item = PauliLetter>,
+{
+    fn from(pauli_letters: T) -> Self {
+        let num_qubits = pauli_letters.len();
+        let mut x_part = Vec::with_capacity(num_qubits);
+        let mut z_part = Vec::with_capacity(num_qubits);
+        for cur_letter in pauli_letters {
+            match cur_letter {
+                PauliLetter::I => {
+                    x_part.push(false);
+                    z_part.push(false);
+                }
+                PauliLetter::X => {
+                    x_part.push(true);
+                    z_part.push(false);
+                }
+                PauliLetter::Y => {
+                    x_part.push(true);
+                    z_part.push(true);
+                }
+                PauliLetter::Z => {
+                    x_part.push(false);
+                    z_part.push(true);
+                }
+            }
+        }
+        Self {
+            first_part: x_part.into(),
+            second_part: z_part.into(),
+            my_n: num_qubits,
+        }
+    }
+}
+
+impl MulAssign<IPower> for PauliString {
+    fn mul_assign(&mut self, rhs: IPower) {
+        self.overall_factor *= rhs;
+    }
+}
+
+impl MulAssign<&PauliString> for PauliString {
+    fn mul_assign(&mut self, rhs: &PauliString) {
+        let mut self_is_y = self.pauli_letters.first_part.clone();
+        *self_is_y &= &self.pauli_letters.second_part;
+        let mut self_is_x = !self.pauli_letters.second_part.clone();
+        *self_is_x &= &self.pauli_letters.first_part;
+        let mut self_is_z = !self.pauli_letters.first_part.clone();
+        *self_is_z &= &self.pauli_letters.second_part;
+
+        let mut rhs_is_y = rhs.pauli_letters.first_part.clone();
+        *rhs_is_y &= &rhs.pauli_letters.second_part;
+        let mut rhs_is_x = !rhs.pauli_letters.second_part.clone();
+        *rhs_is_x &= &rhs.pauli_letters.first_part;
+        let mut rhs_is_z = !rhs.pauli_letters.first_part.clone();
+        *rhs_is_z &= &rhs.pauli_letters.second_part;
+
+        let mut extra_factors_of_i: u8 = 0;
+
+        {
+            let mut self_is_x_rhs_is_y = self_is_x.clone();
+            *self_is_x_rhs_is_y &= &rhs_is_y;
+            let self_is_x_rhs_is_y = self_is_x_rhs_is_y.count_ones();
+            extra_factors_of_i += u8::try_from(self_is_x_rhs_is_y % 4).unwrap();
+        }
+        {
+            let mut self_is_x_rhs_is_z = self_is_x.clone();
+            *self_is_x_rhs_is_z &= &rhs_is_z;
+            let self_is_x_rhs_is_z = self_is_x_rhs_is_z.count_ones();
+            extra_factors_of_i += u8::try_from((self_is_x_rhs_is_z % 4) * 3).unwrap();
+        }
+
+        {
+            let mut self_is_y_rhs_is_z = self_is_y.clone();
+            *self_is_y_rhs_is_z &= &rhs_is_z;
+            let self_is_y_rhs_is_z = self_is_y_rhs_is_z.count_ones();
+            extra_factors_of_i += u8::try_from(self_is_y_rhs_is_z % 4).unwrap();
+        }
+        {
+            let mut self_is_y_rhs_is_x = self_is_y.clone();
+            *self_is_y_rhs_is_x &= &rhs_is_x;
+            let self_is_y_rhs_is_x = self_is_y_rhs_is_x.count_ones();
+            extra_factors_of_i += u8::try_from((self_is_y_rhs_is_x % 4) * 3).unwrap();
+        }
+
+        {
+            let mut self_is_z_rhs_is_x = self_is_z.clone();
+            *self_is_z_rhs_is_x &= &rhs_is_x;
+            let self_is_z_rhs_is_x = self_is_z_rhs_is_x.count_ones();
+            extra_factors_of_i += u8::try_from(self_is_z_rhs_is_x % 4).unwrap();
+        }
+        {
+            let mut self_is_z_rhs_is_y = self_is_z.clone();
+            *self_is_z_rhs_is_y &= &rhs_is_y;
+            let self_is_z_rhs_is_y = self_is_z_rhs_is_y.count_ones();
+            extra_factors_of_i += u8::try_from((self_is_z_rhs_is_y % 4) * 3).unwrap();
+        }
+
+        self.overall_factor += extra_factors_of_i % 4;
+        self.pauli_letters += &rhs.pauli_letters;
+    }
+}
+
+pub struct SGenerators {
+    generating_ms: Vec<PauliString>,
+}
+
+impl SGenerators {
+    /// Create a new set of generators for an abelian subgroup of `P_n`
+    /// Check that the generators actually all commute only if the `verify` flag says so.
+    ///
+    /// # Panics
+    ///
+    /// If we are doing verification and either there is not a consistent `n` for the number of qubits
+    /// or they don't actually commute.
+    ///
+    pub fn new(generating_ms: Vec<PauliString>, verify: bool) -> Self {
+        if verify {
+            let mut num_qubits_each = generating_ms.iter().map(|mi| mi.pauli_letters.my_n);
+            let all_should_be_this = num_qubits_each.next().unwrap();
+            assert!(num_qubits_each.all(|num_qubits_now| num_qubits_now == all_should_be_this));
+            for idx in 0..generating_ms.len() {
+                for jdx in 0..idx {
+                    assert!(
+                        generating_ms[idx].commutes_with(&generating_ms[jdx]),
+                        "{} does not commute with {}",
+                        generating_ms[idx],
+                        generating_ms[jdx]
+                    );
+                }
+            }
+        }
+        Self { generating_ms }
+    }
+
+    pub fn num_qubits(&self) -> usize {
+        self.generating_ms[0].pauli_letters.my_n
+    }
+
+    /// Assuming these were `n-k` independent generators
+    ///
+    /// # Panics
+    ///
+    /// If instead, we are verifying independence of the generators,
+    /// then panic if they are not actually independent.
+    pub fn my_k(&self, verify: bool) -> usize {
+        if verify {
+            let as_matrix = self.as_g_matrix();
+            assert_eq!(as_matrix.rank(), self.generating_ms.len());
+        }
+        self.num_qubits() - self.generating_ms.len()
+    }
+
+    /// Is it giving a maximal isotropic subspace
+    pub fn is_lagrangian(&self) -> bool {
+        self.num_qubits() == self.generating_ms.len()
+    }
+
+    pub fn as_g_matrix(&self) -> BitMatrix {
+        let num_qubits = self.num_qubits();
+        BitMatrix::vstack_from_owned_iter(self.generating_ms.iter().map(|mi| {
+            let left_part = BitMatrix::row_vector(num_qubits, mi.pauli_letters.first_part.clone());
+            let right_part =
+                BitMatrix::row_vector(num_qubits, mi.pauli_letters.second_part.clone());
+            left_part.hstack(&right_part)
+        }))
+    }
+
+    /// Changes the presentation of the group
+    /// according to Gaussian elimination on the G-matrix.
+    pub fn change_presentation(&mut self, blocksize: usize) {
+        let mut as_matrix = self.as_g_matrix();
+        as_matrix.gauss_with_proxy(true, blocksize, self);
+        debug_assert_eq!(self.as_g_matrix(), as_matrix);
+    }
+
+    pub fn syndrome(&self, error: &PauliString) -> BitVec {
+        BitVec::from(
+            self.generating_ms
+                .iter()
+                .map(|mi| !mi.commutes_with(error))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// The weight 1 Pauli strings that centralize this subgroup
+    /// They might be within this subgroup already or not
+    #[allow(clippy::missing_panics_doc)]
+    pub fn weight_one_centralizers(&self) -> impl Iterator<Item = PauliString> {
+        let num_qubits = self.num_qubits();
+        let mut to_return = Vec::with_capacity(num_qubits);
+        let as_matrix = self.as_g_matrix();
+        let num_rows = as_matrix.rows();
+        let zero_col = BitMatrix::zeros(num_rows, 1);
+        for idx in 0..num_qubits {
+            let idxth_col = as_matrix.select_cols(&[idx]).expect("This column exists");
+            let idx_plus_nth_col = as_matrix
+                .select_cols(&[idx + num_qubits])
+                .expect("This column exists");
+            let idxth_is_zero = idxth_col == zero_col;
+            let idx_plus_nth_is_zero = idx_plus_nth_col == zero_col;
+            let both_cols_same = idxth_col == idx_plus_nth_col;
+            if idxth_is_zero && idx_plus_nth_is_zero {
+                to_return.push(PauliString::weight_one(
+                    idx,
+                    num_qubits,
+                    PauliLetter::X,
+                    IPower::One,
+                ));
+                to_return.push(PauliString::weight_one(
+                    idx,
+                    num_qubits,
+                    PauliLetter::Y,
+                    IPower::One,
+                ));
+                to_return.push(PauliString::weight_one(
+                    idx,
+                    num_qubits,
+                    PauliLetter::Z,
+                    IPower::One,
+                ));
+            } else if idxth_is_zero {
+                to_return.push(PauliString::weight_one(
+                    idx,
+                    num_qubits,
+                    PauliLetter::Z,
+                    IPower::One,
+                ));
+            } else if idx_plus_nth_is_zero {
+                to_return.push(PauliString::weight_one(
+                    idx,
+                    num_qubits,
+                    PauliLetter::X,
+                    IPower::One,
+                ));
+            } else if both_cols_same {
+                to_return.push(PauliString::weight_one(
+                    idx,
+                    num_qubits,
+                    PauliLetter::Y,
+                    IPower::One,
+                ));
+            }
+        }
+        to_return.into_iter().flat_map(|with_no_prefactor| {
+            let mut to_return = [
+                with_no_prefactor.clone(),
+                with_no_prefactor.clone(),
+                with_no_prefactor.clone(),
+                with_no_prefactor,
+            ];
+            to_return[1] *= IPower::PlusI;
+            to_return[2] *= IPower::NegOne;
+            to_return[3] *= IPower::NegI;
+            to_return
+        })
+    }
+}
+
+impl RowOps for SGenerators {
+    fn add_row(&mut self, from: usize, to: usize) {
+        let from_piece = self.generating_ms[from].clone();
+        self.generating_ms[to] *= &from_piece;
+    }
+
+    fn swap_rows(&mut self, from: usize, to: usize) {
+        self.generating_ms.swap(from, to);
+    }
+}
+
+mod test {
+
+    #[test]
+    fn pauli_1() {
+        use super::{IPower, PauliString};
+        let x_pauli = PauliString::parse("X").expect("Manifestly a Pauli String");
+        let y_pauli = PauliString::parse("Y").expect("Manifestly a Pauli String");
+        let z_pauli = PauliString::parse("Z").expect("Manifestly a Pauli String");
+        let xyz_pauli = [x_pauli, y_pauli, z_pauli];
+        for cur_squaring in &xyz_pauli {
+            let mut cur_testing = cur_squaring.clone();
+            cur_testing *= cur_squaring;
+            assert_eq!(
+                cur_testing,
+                PauliString::parse("I").expect("Manifestly a Pauli String")
+            );
+        }
+        for (which_left, cur_left) in xyz_pauli.iter().enumerate() {
+            for (which_right, cur_right) in xyz_pauli.iter().enumerate() {
+                if which_right == which_left {
+                    continue;
+                }
+                let mut cur_testing = cur_left.clone();
+                cur_testing *= cur_right;
+                let which_expected = [0, 1, 2]
+                    .into_iter()
+                    .find(|idx| ![which_left, which_right].contains(idx))
+                    .unwrap();
+                if (which_right + 3 - which_left) % 3 == 1 {
+                    cur_testing *= IPower::NegI;
+                } else {
+                    cur_testing *= IPower::PlusI;
+                }
+                assert_eq!(
+                    cur_testing, xyz_pauli[which_expected],
+                    "{}*{} vs {}",
+                    cur_left, cur_right, xyz_pauli[which_expected]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pauli_string_mul() {
+        use super::PauliString;
+        let mut m1 = PauliString::parse("XZZIX").expect("Manifestly a Pauli String");
+        let m0 = PauliString::parse("IIIII").expect("Manifestly a Pauli String");
+        m1 *= &m0;
+        assert_eq!(
+            m1,
+            PauliString::parse("XZZIX").expect("Manifestly a Pauli String")
+        );
+
+        let m2 = PauliString::parse("ZXIZX").expect("Manifestly a Pauli String");
+        m1 *= &m2;
+        assert_eq!(
+            m1,
+            PauliString::parse("YYZZI").expect("Manifestly a Pauli String")
+        );
+    }
+
+    #[test]
+    fn stabilizer_5_1_3() {
+        use super::PauliString;
+        let m1 = PauliString::parse("XZZIX").expect("Manifestly a Pauli String");
+        let m2 = PauliString::parse("ZXIZX").expect("Manifestly a Pauli String");
+        let m3 = PauliString::parse("IZXZY").expect("Manifestly a Pauli String");
+        let m4 = PauliString::parse("ZIZXY").expect("Manifestly a Pauli String");
+        let ms = [m1, m2, m3, m4];
+        let expected_weights = [4, 4, 4, 4];
+        for (cur_m, expected_weight) in ms.iter().zip(expected_weights) {
+            let as_symp = &cur_m.pauli_letters;
+            assert_eq!(cur_m.weight(), expected_weight);
+            assert_eq!(as_symp.weight(), expected_weight);
+        }
+        for idx in 0..4 {
+            let ms_idx = &ms[idx];
+            for jdx in 0..=idx {
+                assert!(
+                    ms_idx.commutes_with(&ms[jdx]),
+                    "{} and {}",
+                    ms_idx.pauli_letters,
+                    ms[jdx].pauli_letters,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn shor_code() {
+        use crate::{PauliString, SGenerators};
+        let shor_shorthand = [
+            "ZZI III III",
+            "IZZ III III",
+            "III ZZI III",
+            "III IZZ III",
+            "III III ZZI",
+            "III III IZZ",
+            "XXX XXX III",
+            "III XXX XXX",
+        ];
+        let mut shor_code = SGenerators::new(
+            shor_shorthand
+                .into_iter()
+                .map(|s| PauliString::parse(s).unwrap())
+                .collect(),
+            true,
+        );
+
+        shor_code.change_presentation(1);
+        // can see that it has change the generators, but not the group
+        //assert!(false, "{}", (0..8).map(|idx| format!("{}\n", shor_code.generating_ms[idx])).collect::<String>());
+    }
+}

--- a/pybindings/src/bitmatrix.rs
+++ b/pybindings/src/bitmatrix.rs
@@ -1,9 +1,10 @@
-#![allow(clippy::must_use_candidate,
+#![allow(
+    clippy::must_use_candidate,
     clippy::return_self_not_must_use,
     clippy::needless_pass_by_value,
     clippy::missing_errors_doc,
     clippy::bool_to_int_with_if,
-    clippy::uninlined_format_args,
+    clippy::uninlined_format_args
 )]
 
 use pyo3::exceptions::PyValueError;

--- a/pybindings/src/bitmatrix.rs
+++ b/pybindings/src/bitmatrix.rs
@@ -1,3 +1,11 @@
+#![allow(clippy::must_use_candidate,
+    clippy::return_self_not_must_use,
+    clippy::needless_pass_by_value,
+    clippy::missing_errors_doc,
+    clippy::bool_to_int_with_if,
+    clippy::uninlined_format_args,
+)]
+
 use pyo3::exceptions::PyValueError;
 use pyo3::{prelude::*, IntoPyObjectExt};
 


### PR DESCRIPTION
Error Correcting Code

Even if you don't want this functionality in this crate itself. Can see which impls were used for them on BitMatrix and BitVec. This would be so the downstream crate could avoid the foreign trait, foreign type problem without using a wrapper.