### PR TITLE
direct numpy conversion and nullspace as matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ name = "bitgauss_pybindings"
 version = "0.0.0"
 dependencies = [
  "bitgauss",
+ "numpy",
  "pyo3",
  "rand",
 ]
@@ -275,6 +276,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,12 +301,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -343,6 +403,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -467,6 +536,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/bitgauss/src/bitmatrix.rs
+++ b/bitgauss/src/bitmatrix.rs
@@ -699,6 +699,26 @@ impl BitMatrix {
 
         basis
     }
+    
+    // added by andi
+    pub fn nullspace_matrix(&self) -> BitMatrix {
+        let basis = self.nullspace();
+
+        let n = self.cols();   // ambient dimension
+        let k = basis.len();   // number of basis vectors
+
+        // Empty basis => n x 0 matrix
+        if k == 0 {
+            return BitMatrix::zeros(n, 0);
+        }
+
+        debug_assert!(basis.iter().all(|v| v.rows() == 1 && v.cols() == n));
+
+        // basis[j] is a 1 x n row-vector, so its i-th entry is bit(0, i).
+        // Put that into column j of the output.
+        BitMatrix::build(n, k, |i, j| basis[j].bit(0, i))
+    }
+
 }
 
 /// Two matrices are considered equal if they represent the same logical matrix, possibly with different

--- a/pybindings/Cargo.toml
+++ b/pybindings/Cargo.toml
@@ -18,5 +18,6 @@ bitgauss = { version = "*", path = "../bitgauss" }
 pyo3 = { version = "0.25.1", features = [
     "extension-module",
     "abi3-py39",
-] }
+]}
+numpy="0.25"
 rand = { workspace = true }

--- a/pybindings/src/bitmatrix.rs
+++ b/pybindings/src/bitmatrix.rs
@@ -1,6 +1,11 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::{prelude::*, IntoPyObjectExt};
 
+/// added by andi
+use numpy::PyReadonlyArray2;
+use numpy::{IntoPyArray, PyArray2};
+
+
 // Assuming these are the original imports/dependencies from your Rust code
 // You'll need to adjust these based on your actual crate structure
 use bitgauss::BitMatrix;
@@ -181,6 +186,13 @@ impl PyBitMatrix {
             .map(|m| PyBitMatrix { inner: m })
             .collect()
     }
+    // added by andi
+    pub fn nullspace_matrix(&self) -> Self {
+        Self {
+            inner: self.inner.nullspace_matrix(),
+        }
+    }
+
 
     /// Returns a copy of the matrix
     pub fn copy(&self) -> Self {
@@ -403,6 +415,30 @@ impl PyBitMatrix {
         let matrix = BitMatrix::build(rows, cols, |i, j| data[i][j] != 0);
         Ok(PyBitMatrix { inner: matrix })
     }
+
+    /// added by andi
+    #[staticmethod]
+    pub fn from_numpy_bool(arr: PyReadonlyArray2<'_, bool>) -> PyResult<Self> {
+        let a = arr.as_array();
+        let (rows, cols) = a.dim();
+
+        let matrix = bitgauss::BitMatrix::build(rows, cols, |i, j| a[[i, j]]);
+
+        //Ok(Self { inner })
+        Ok(PyBitMatrix { inner: matrix })
+    }
+
+    pub fn to_numpy_bool<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray2<bool>> {
+        let rows = self.inner.rows();
+        let cols = self.inner.cols();
+
+        let arr = numpy::ndarray::Array2::from_shape_fn((rows, cols), |(i, j)| {
+            self.inner.bit(i, j)
+        });
+
+        arr.into_pyarray(py)
+    }
+
 
     /// Matrix equality comparison
     pub fn __eq__(&self, other: &PyBitMatrix) -> bool {


### PR DESCRIPTION
Hi Alex,

Thanks a lot for creating this tool, it's been very useful for a project related to transversal logic gates! I (or rather Copilot) made two small modifications for my purposes. Wondering if some of this also might be useful to others so I'm sending this pull request - feel free to ignore of course.

(1) I added direct conversion from numpy matrices to bitmatrices. I'm creating the matrices making heavy use of numpy's powerful indexing/slicing methods which BitMatrix doesn't implement, and only performing RREF using your code. Converting very large numpy matrices to BitMatrix via pure-python lists is extremely slow.

(2) I've added a wrapper that returns the nullspace as a matrix, not as a list. More natural for my purposes and it allows me to directly convert to numpy with change (1).

(3) This is not a change, but a small bug I noticed: The kernel of a 0 x n matrix is all n-dimensional space, not empty. Right now, the code returns the empty list. I didn't fix this in the repo but patched it in my python code. I'm wondering if the code would still run without the first equality in the check
'''if self.rows() == 0 || self.cols() == 0 {
            return Vec::new();
        }
'''
which would fix it.

Best,
Andi